### PR TITLE
Allow additional ClassType modifiers

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -126,10 +126,11 @@ export default grammar({
       $.EnumType,
       $._conditional_body,
     ],
+    [$.AbstractType, $.ClassType],
+    [$.AbstractType, $.ClassType, $._conditional_body],
     [$.AbstractType, $.ClassType, $.DefType, $.EnumType],
     [$.AbstractType, $.DefType, $.EnumType, $._conditional_body],
     [$.AbstractType, $.DefType, $.EnumType],
-    [$.AbstractType, $._conditional_body],
     [$.ClassMethod, $._conditional_body],
     [$.ClassType, $.ClassVar, $.ClassMethod],
     [$.ClassType, $.ClassVar, $.ClassMethod, $._conditional_body],
@@ -769,7 +770,7 @@ export default grammar({
 
     ClassType: ($) =>
       seq(
-        optional(repeat1(choice($.visibility, "extern", "final"))),
+        optional(repeat1(choice($.visibility, "abstract", "extern", "final"))),
         choice("class", "interface"),
         $._type_decl_signature,
         optional(seq("extends", field("extends", $.TypePath))),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -61,6 +61,7 @@
   "macro"
   "extern"
 ] @keyword.modifier
+(ClassType "abstract" @keyword.modifier)
 
 ; "macro" @macro
 

--- a/test/corpus/type_decl.txt
+++ b/test/corpus/type_decl.txt
@@ -88,6 +88,18 @@ extern class A {}
   (ClassType
     name: (type_name)))
 
+==========================
+abstract class declaration
+==========================
+
+abstract class A {}
+
+---
+
+(module
+  (ClassType
+    name: (type_name)))
+
 =============================
 enum declaration field params
 =============================

--- a/test/highlight/abstract.hx
+++ b/test/highlight/abstract.hx
@@ -1,0 +1,8 @@
+abstract Foo(Int) {}
+// <- keyword.declaration
+//       ^ type
+//          ^ punctuation.bracket
+//           ^ type
+//              ^ punctuation.bracket
+//                ^ punctuation.bracket
+//                 ^ punctuation.bracket

--- a/test/highlight/class.hx
+++ b/test/highlight/class.hx
@@ -44,3 +44,10 @@ extern class Main {}
 //           ^ type
 //                ^ punctuation.bracket
 //                 ^ punctuation.bracket
+
+abstract class Main {}
+// <- keyword.modifier
+//       ^ keyword.declaration
+//             ^ type
+//                  ^ punctuation.bracket
+//                   ^ punctuation.bracket


### PR DESCRIPTION
- Classes can now be marked as extern: <https://haxe.org/manual/lf-externs.html>
- Classes can now be marked as final: <https://haxe.org/manual/types-class-inheritance.html#since-haxe-4.0.0>
- Classes can now be marked as abstract: <https://haxe.org/manual/types-abstract-class.html>